### PR TITLE
fix: Account ingestion fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "identity-fusion",
-	"version": "1.2.1",
+	"version": "1.2.2",
 	"main": "dist/index.js",
 	"scripts": {
 		"clean": "shx rm -rf ./dist",

--- a/src/contextHelper.ts
+++ b/src/contextHelper.ts
@@ -364,6 +364,14 @@ export class ContextHelper {
                 this.accounts.push(account)
             }
         }
+
+        // Build the account source map for faster lookups
+        logger.debug(lm('Building account source map for faster lookups.', c))
+        this.buildAccountSourceMap()
+
+        // Build accounts by identity ID map for faster lookups
+        logger.debug(lm('Building accounts by identity ID map for faster lookups.', c))
+        this.buildAccountsByIdentityIdLookup()
     }
 
     listProcessedAccountIDs(): string[] {
@@ -416,14 +424,6 @@ export class ContextHelper {
         // Build the authoritative accounts lookup map for O(1) access
         logger.debug(lm('Building authoritative accounts lookup map for faster access.', c))
         this.buildAuthoritativeAccountsLookup()
-
-        // Build the account source map for faster lookups
-        logger.debug(lm('Building account source map for faster lookups.', c))
-        this.buildAccountSourceMap()
-
-        // Build accounts by identity ID map for faster lookups
-        logger.debug(lm('Building accounts by identity ID map for faster lookups.', c))
-        this.buildAccountsByIdentityIdLookup()
     }
 
     private buildAuthoritativeAccountsLookup(): void {


### PR DESCRIPTION
This moves the building of the account maps to after the accounts are fetched instead of when the authoritativeAccounts are fetched. This solves a problem with a race condition where not all accounts were mapped properly. 