### PR TITLE
feat: Reference LCS Transform Option

### DIFF
--- a/connector-spec.json
+++ b/connector-spec.json
@@ -82,6 +82,12 @@
                             "required": false
                         },
                         {
+                            "key": "referenceTransformName",
+                            "label": "Lifecycle Reference Transform Name",
+                            "type": "text",
+                            "required": false
+                        },
+                        {
                             "key": "attributeMerge",
                             "label": "Default attribute merge from multiple sources",
                             "type": "radio",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "identity-fusion",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "main": "dist/index.js",
     "scripts": {
         "clean": "shx rm -rf ./dist",

--- a/src/contextHelper.ts
+++ b/src/contextHelper.ts
@@ -1431,9 +1431,19 @@ export class ContextHelper {
                         values: attributeValues,
                         ignoreErrors: true,
                     },
-                },
+                }
             },
             internal: false,
+        }
+
+        if (this.config.referenceTransformName && this.config.referenceTransformName != "") {
+            transformDef.attributes.value = "#if($processed == 'false')staging#{else}$lifeCycleStatus#end"
+            transformDef.attributes.lifeCycleStatus = {
+                type: "reference",
+                attributes: {
+                    name: this.config.referenceTransformName
+                }
+            }
         }
 
         try {

--- a/src/model/config.ts
+++ b/src/model/config.ts
@@ -54,4 +54,5 @@ export interface Config {
     batchProcessing?: boolean
     batchSize?: number
     resetProcessingFlag?: boolean
+    referenceTransformName?: string
 }


### PR DESCRIPTION
This new feature creates an additional configuration option of a text field to enter a transform name. 

The current connector builds a default transform with 2 possible LCS: staging and active. Staging is necessary for the processing of the connector, but in place of active should be the default LCS calculation. 

Modifying the transform after connector deployment is possible, but when certain config options are updated, the transform replaces itself. Adding this additional configuration option allows for the custom LCS logic to be maintained in a separate transform while still enabling the use of the OOB connector transform. 