### PR TITLE
Add 'candidate' status to identities in pending reviews and enhance form handling

### DIFF
--- a/src/data/status.ts
+++ b/src/data/status.ts
@@ -20,4 +20,5 @@ export const statuses: StatusSource[] = [
     { id: 'requested', name: 'Requested', description: 'Account was requested' },
     { id: 'uncorrelated', name: 'Uncorrelated', description: 'Account has sources accounts pending correlation' },
     { id: 'activeReviews', name: 'Active reviews', description: 'Account has active fusion reviews' },
+    { id: 'candidate', name: 'Candidate', description: 'This identity is part of a pending Fusion review' },
 ]

--- a/src/services/formService/formBuilder.ts
+++ b/src/services/formService/formBuilder.ts
@@ -56,6 +56,10 @@ export const buildFormInput = (
         })
     }
 
+    // Store candidate identity IDs for tracking candidate status on subsequent aggregations.
+    // This allows extracting candidate IDs from pending form instances without parsing keys.
+    formInput.candidates = candidates.map((c) => c.id).join(',')
+
     // Candidate attributes and scores (flat keys for form elements)
     candidates.forEach((candidate) => {
         if (!candidate || !candidate.id) return


### PR DESCRIPTION
- Introduced a new status 'candidate' for identities involved in pending Fusion reviews.
- Updated form handling to track candidate identity IDs from form inputs.
- Enhanced the FusionService to apply the 'candidate' status during aggregation and form processing.
- Improved documentation for methods related to candidate identity management.