### PR TITLE
Fix uneven shadow margins in report and review email templates

### DIFF
--- a/src/services/messagingService/helpers.ts
+++ b/src/services/messagingService/helpers.ts
@@ -13,10 +13,10 @@ const DEFAULT_FUSION_REPORT_TEMPLATE = `<!DOCTYPE html>
 <body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; color:#1f2937; margin:0; padding:0; background:#f3f6fb;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" align="center" style="width:100%; border-collapse:collapse;">
     <tr>
-      <td align="center" style="padding:0 16px;">
+      <td align="center" style="padding:0;">
         <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; max-width:920px; border-collapse:collapse;">
           <tr>
-            <td style="padding:12px 20px;">
+            <td style="padding:12px;">
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-collapse:separate; border-spacing:0; background:#ffffff; border:1px solid #e6ebf5; border-radius:14px; box-shadow:0 12px 30px rgba(16,24,40,0.12);">
                 <tr>
                   <td style="padding:14px 24px 14px 14px;">
@@ -302,10 +302,10 @@ const DEFAULT_FUSION_REVIEW_TEMPLATE = `<!DOCTYPE html>
 <body style="margin:0; padding:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; background:#f3f6fb;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" align="center" style="width:100%; border-collapse:collapse;">
         <tr>
-            <td align="center" style="padding:0 16px;">
+            <td align="center" style="padding:0;">
                 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-collapse:collapse;">
                     <tr>
-                        <td style="padding:12px 20px;">
+                        <td style="padding:12px;">
                             <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-collapse:separate; border-spacing:0; background:#ffffff; border:1px solid #e6ebf5; border-radius:14px; box-shadow:0 12px 30px rgba(16,24,40,0.12);">
                                 <tr>
                                     <td style="padding:14px 24px 14px 14px;">

--- a/src/services/messagingService/templates/fusion-report.hbs
+++ b/src/services/messagingService/templates/fusion-report.hbs
@@ -291,10 +291,10 @@
 <body style="margin:0; padding:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; background:#f3f6fb;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" align="center" style="width:100%; border-collapse:collapse; white-space:normal;">
         <tr>
-            <td align="center" style="padding:0 16px;">
+            <td align="center" style="padding:0;">
                 <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse:collapse; width:100%; max-width:920px;">
                     <tr>
-                        <td style="padding:12px 20px;">
+                        <td style="padding:12px;">
                             <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-collapse:separate; border-spacing:0; background:#ffffff; border:1px solid #e6ebf5; border-radius:14px; box-shadow:0 12px 30px rgba(16,24,40,0.12);">
                                 <tr>
                                     <td style="padding:14px 24px 14px 14px;">

--- a/src/services/messagingService/templates/fusion-review.hbs
+++ b/src/services/messagingService/templates/fusion-review.hbs
@@ -28,10 +28,10 @@
 <body style="margin:0; padding:0; font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif; background:#f3f6fb;">
     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" align="center" style="width:100%; border-collapse:collapse;">
         <tr>
-            <td align="center" style="padding:0 16px;">
+            <td align="center" style="padding:0;">
                 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-collapse:collapse;">
                     <tr>
-                        <td style="padding:12px 20px;">
+                        <td style="padding:12px;">
                             <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%; border-collapse:separate; border-spacing:0; background:#ffffff; border:1px solid #e6ebf5; border-radius:14px; box-shadow:0 12px 30px rgba(16,24,40,0.12);">
                                 <tr>
                                     <td style="padding:14px 24px 14px 14px;">


### PR DESCRIPTION
## Summary
- The white card in report/review emails had a 12px top gap but a 36px left gap, making the layout visually unbalanced
- Root cause: two nested `<td>` wrappers contributed horizontal padding (`padding:0 16px` + `padding:12px 20px`) but only the inner one contributed top padding
- Normalised both wrappers to `padding:0` / `padding:12px` for a uniform 12px margin on all four sides

## Files changed
- `src/services/messagingService/helpers.ts` — fixed in both the report and review in-code templates
- `src/services/messagingService/templates/fusion-report.hbs` — kept in sync (reference template)
- `src/services/messagingService/templates/fusion-review.hbs` — kept in sync (reference template)

## Test plan
- [ ] Trigger an aggregation that generates a report email and confirm equal margins around the white card on all sides
- [ ] Verify the review email renders with the same uniform spacing