### PR TITLE
chore: add Codey-Bot Jira sync config

### DIFF
--- a/.github/codey-bot.yml
+++ b/.github/codey-bot.yml
@@ -1,0 +1,31 @@
+# Codey-Bot Jira sync configuration.
+# Dry-run mode validates wiring without creating Jira issues.
+dryRun: true
+
+spam:
+  enabled: false
+community:
+  welcomeMessage: null
+  newContributorLabel: null
+  autoLabeler: {}
+pr:
+  requireBody: false
+  conventionalCommits: false
+  autoFormat: false
+qualityGate:
+  enabled: false
+stale:
+  enabled: false
+
+jiraSync:
+  enabled: true
+  projectKey: DEVREL
+  epicKey: DEVREL-2333
+  issueType: Task
+  syncIssues: true
+  syncPullRequests: false
+  labels:
+    - github-sync
+    - sailpoint-oss
+    - saas-connectivity
+    - repo-colab-saas-conn-sailpoint-identity-fusion


### PR DESCRIPTION
## Summary
- Adds dry-run Codey-Bot Jira sync configuration for `colab-saas-conn-sailpoint-identity-fusion`.
- Routes GitHub issues to `DEVREL-2333` (SaaS Connectivity documentation enhancements) in the DEVREL Jira project.
- Disables non-Jira Codey-Bot features in this repo config unless maintainers opt in later.

## Jira Sync
- Project: `DEVREL`
- Epic: `DEVREL-2333`
- Issue type: `Task`
- Mode: `dryRun: true` for validation only
- Labels: `github-sync`, `sailpoint-oss`, `saas-connectivity`, `repo-colab-saas-conn-sailpoint-identity-fusion`

## Rollout Notes
This PR does not create Jira issues while `dryRun` remains true. After maintainers verify Codey-Bot logs and the DEVREL epic destination, a follow-up PR can switch `dryRun` to false.

Generated as part of the public `sailpoint-oss` repo-to-DEVREL Jira wiring rollout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change with dry-run enabled; no application or auth logic is modified.
> 
> **Overview**
> Introduces **Codey-Bot** configuration for this repo via `.github/codey-bot.yml`, with **`dryRun: true`** so wiring can be validated without creating Jira issues.
> 
> **Jira sync** is enabled for GitHub **issues** (not PRs) into project **`DEVREL`**, epic **`DEVREL-2333`**, issue type **`Task`**, with labels including `github-sync`, `sailpoint-oss`, `saas-connectivity`, and a repo-specific label.
> 
> Spam handling, community automation, PR gates (body, conventional commits, auto-format), quality gate, and stale-bot are all **explicitly turned off** in this config so only Jira sync is active until maintainers opt in later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0572e0c7a8dc52ed597128e21cd9f3f58c898ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->